### PR TITLE
Feature/jmp

### DIFF
--- a/emulator/src/core/emulator.rs
+++ b/emulator/src/core/emulator.rs
@@ -24,6 +24,14 @@ impl Emulator {
         let opcode = self.ram[self.pc];
         self.pc += 1;
         match opcode {
+            0xc0 => {
+                // RNZ
+                self.ret_not("zero")?;
+            }
+            0xc1 => {
+                // Unimplemented
+                unimplemented!();
+            }
             0xc2 => {
                 // JNZ adr
                 self.jmp_not("zero")?;
@@ -44,13 +52,11 @@ impl Emulator {
             }
             0xc8 => {
                 // RZ
-                if self.reg.get_flag("zero") {
-                    self.pc = self.pop()?;
-                }
+                self.ret_if("zero")?;
             }
             0xc9 => {
                 // RET
-                self.pc = self.pop()?;
+                self.ret()?;
             }
             0xca => {
                 // JZ adr
@@ -74,9 +80,7 @@ impl Emulator {
             }
             0xd0 => {
                 // RNC
-                if !self.reg.get_flag("carry") {
-                    self.pc = self.pop()?;
-                }
+                self.ret_not("carry")?;
             }
             0xd1 => {
                 // POP D
@@ -109,7 +113,7 @@ impl Emulator {
             }
             0xd8 => {
                 // RC
-                unimplemented!()
+                self.ret_if("carry")?;
             }
             0xd9 => {
                 // no-op
@@ -140,8 +144,8 @@ impl Emulator {
                 self.call(0x18)?;
             }
             0xe0 => {
-                // Unimplemented
-                unimplemented!()
+                // RPO
+                self.ret_not("parity")?;
             }
             0xe1 => {
                 // Unimplemented
@@ -172,8 +176,8 @@ impl Emulator {
                 self.call(0x20)?;
             }
             0xe8 => {
-                // Unimplemented
-                unimplemented!()
+                // RPE
+                self.ret_if("parity")?;
             }
             0xe9 => {
                 // Unimplemented
@@ -204,8 +208,8 @@ impl Emulator {
                 self.call(0x28)?;
             }
             0xf0 => {
-                // Unimplemented
-                unimplemented!()
+                // RP
+                self.ret_not("sign")?;
             }
             0xf1 => {
                 // Unimplemented
@@ -236,8 +240,8 @@ impl Emulator {
                 self.call(0x30)?;
             }
             0xf8 => {
-                // Unimplemented
-                unimplemented!()
+                // RM
+                self.ret_if("sign")?;
             }
             0xf9 => {
                 // Unimplemented
@@ -318,6 +322,20 @@ impl Emulator {
     fn call(&mut self, adr: u16) -> EResult<()> {
         self.push(self.pc)?;
         self.pc = adr;
+        Ok(())
+    }
+
+    fn ret_if(&mut self, flag: &str) -> EResult<()> {
+        if self.reg.get_flag(flag) {
+            self.ret()?;
+        }
+        Ok(())
+    }
+
+    fn ret_not(&mut self, flag: &str) -> EResult<()> {
+        if !self.reg.get_flag(flag) {
+            self.ret()?;
+        }
         Ok(())
     }
 

--- a/emulator/src/core/emulator.rs
+++ b/emulator/src/core/emulator.rs
@@ -117,6 +117,82 @@ impl Emulator {
                 // JC adr
                 self.jmp_if("carry");
             }
+            0xdb => {
+                // Unimplemented
+                unimplemented!()
+            }
+            0xdc => {
+                // Unimplemented
+                unimplemented!()
+            }
+            0xdd => {
+                // Unimplemented
+                unimplemented!()
+            }
+            0xde => {
+                // Unimplemented
+                unimplemented!()
+            }
+            0xdf => {
+                // Unimplemented
+                unimplemented!()
+            }
+            0xe0 => {
+                // Unimplemented
+                unimplemented!()
+            }
+            0xe1 => {
+                // Unimplemented
+                unimplemented!()
+            }
+            0xe2 => {
+                // Unimplemented
+                unimplemented!()
+            }
+            0xe3 => {
+                // Unimplemented
+                unimplemented!()
+            }
+            0xe4 => {
+                // Unimplemented
+                unimplemented!()
+            }
+            0xe5 => {
+                // Unimplemented
+                unimplemented!()
+            }
+            0xe6 => {
+                // Unimplemented
+                unimplemented!()
+            }
+            0xe7 => {
+                // Unimplemented
+                unimplemented!()
+            }
+            0xe8 => {
+                // Unimplemented
+                unimplemented!()
+            }
+            0xe9 => {
+                // Unimplemented
+                unimplemented!()
+            }
+            0xea => {
+                // Unimplemented
+                unimplemented!()
+            }
+            0xeb => {
+                // Unimplemented
+                unimplemented!()
+            }
+            0xec => {
+                // Unimplemented
+                unimplemented!()
+            }
+            0xed => {
+                // Unimplemented
+                unimplemented!()
+            }
             _ => unimplemented!("Opcode not yet implemented")
         }
         Ok(())

--- a/emulator/src/core/emulator.rs
+++ b/emulator/src/core/emulator.rs
@@ -25,13 +25,6 @@ impl Emulator {
         match opcode {
             0xc2 => {
                 // JNZ adr
-                /*
-                if !self.reg.get_flag("zero") {
-                    self.pc = self.read_addr();
-                } else {
-                    self.pc += 2;
-                }
-                */
                 self.jmp_not("zero");
             }
             0xc3 => {
@@ -60,13 +53,6 @@ impl Emulator {
             }
             0xca => {
                 // JZ adr
-                /*
-                if self.reg.get_flag("zero") {
-                    self.pc = self.read_addr();
-                } else {
-                    self.pc += 2;
-                }
-                */
                 self.jmp_if("zero");
                 
             }
@@ -103,11 +89,7 @@ impl Emulator {
             }
             0xd2 => {
                 // JNC adr
-                if !self.reg.get_flag("carry") {
-                    self.pc = self.read_addr();
-                } else {
-                    self.pc += 2;
-                }
+                self.jmp_not("carry");
             }
             0xd3 => {
                 // OUT

--- a/emulator/src/core/emulator.rs
+++ b/emulator/src/core/emulator.rs
@@ -148,16 +148,16 @@ impl Emulator {
                 unimplemented!()
             }
             0xe2 => {
-                // Unimplemented
-                unimplemented!()
+                // JPO adr
+                self.jmp_not("parity")?;
             }
             0xe3 => {
                 // Unimplemented
                 unimplemented!()
             }
             0xe4 => {
-                // Unimplemented
-                unimplemented!()
+                // CPO adr
+                self.call_not("parity")?;
             }
             0xe5 => {
                 // Unimplemented
@@ -180,18 +180,90 @@ impl Emulator {
                 unimplemented!()
             }
             0xea => {
-                // Unimplemented
-                unimplemented!()
+                // JPE adr
+                self.jmp_if("parity")?;
             }
             0xeb => {
                 // Unimplemented
                 unimplemented!()
             }
             0xec => {
+                // CPE
+                self.call_if("parity")?;
+            }
+            0xed => {
                 // Unimplemented
                 unimplemented!()
             }
-            0xed => {
+            0xee => {
+                // Unimplemented
+                unimplemented!()
+            }
+            0xef => {
+                // Unimplemented
+                unimplemented!()
+            }
+            0xf0 => {
+                // Unimplemented
+                unimplemented!()
+            }
+            0xf1 => {
+                // Unimplemented
+                unimplemented!()
+            }
+            0xf2 => {
+                // JP adr
+                self.jmp_not("sign")?;
+            }
+            0xf3 => {
+                // Unimplemented
+                unimplemented!()
+            }
+            0xf4 => {
+                // CP adr
+                self.call_not("sign")?;
+            }
+            0xf5 => {
+                // Unimplemented
+                unimplemented!()
+            }
+            0xf6 => {
+                // Unimplemented
+                unimplemented!()
+            }
+            0xf7 => {
+                // Unimplemented
+                unimplemented!()
+            }
+            0xf8 => {
+                // Unimplemented
+                unimplemented!()
+            }
+            0xf9 => {
+                // Unimplemented
+                unimplemented!()
+            }
+            0xfa => {
+                // JM adr
+                self.jmp_if("sign")?;
+            }
+            0xfb => {
+                // Unimplemented
+                unimplemented!()
+            }
+            0xfc => {
+                // CM adr
+                self.call_if("sign")?;
+            }
+            0xfd => {
+                // Unimplemented
+                unimplemented!()
+            }
+            0xfe => {
+                // Unimplemented
+                unimplemented!()
+            }
+            0xff => {
                 // Unimplemented
                 unimplemented!()
             }
@@ -325,6 +397,43 @@ mod tests {
 
         e.execute_next().expect("Fuck");
         assert_eq!(e.pc, 0x0);
+    }
+
+    #[test]
+    fn jmp_if() {
+        let mut e = Emulator::new();
+
+        e.ram.load_vec(vec![0x04, 0x00, 0x00, 0x00], 0);
+
+        // Performs
+        // a) one failing jmp (-> pc = 2)
+        // b) one succeeding jmp (pc = ram[pc] = ram[2] -> 0)
+        // c) Back in starting position
+        // -> Repeat for each flag
+        for flag in vec!["zero", "carry", "sign", "parity", "aux"] { 
+            e.jmp_if(flag).expect("");
+            assert_eq!(e.pc, 2);
+            e.reg.set_flag(flag);
+            e.jmp_if(flag).expect("");
+            assert_eq!(e.pc, 0);
+        }
+    }
+
+    #[test]
+    fn jmp_not() {
+        let mut e = Emulator::new();
+
+        e.ram.load_vec(vec![0x04, 0x00, 0x00, 0x00], 0);
+        e.reg.set_flags(0xff);
+
+        // same as tests::jmp_if
+        for flag in vec!["zero", "carry", "sign", "parity", "aux"] { 
+            e.jmp_not(flag).expect("");
+            assert_eq!(e.pc, 2);
+            e.reg.flip_flag(flag);
+            e.jmp_not(flag).expect("");
+            assert_eq!(e.pc, 0);
+        }
     }
 
     #[test]

--- a/emulator/src/core/emulator.rs
+++ b/emulator/src/core/emulator.rs
@@ -470,10 +470,12 @@ mod tests {
         for flag in vec!["zero", "carry", "sign", "parity", "aux"] {
             e.call_if(flag).expect("");
             assert_eq!(e.pc, 2);
+            e.ret_if(flag).expect("");
+            assert_eq!(e.pc, 2);
             e.reg.set_flag(flag);
             e.call_if(flag).expect("");
             assert_eq!(e.pc, 0x1111);
-            e.ret().expect("");
+            e.ret_if(flag).expect("");
             assert_eq!(e.pc, 4);
             e.pc = 0;
         }
@@ -491,10 +493,12 @@ mod tests {
         for flag in vec!["zero", "carry", "sign", "parity", "aux"] {
             e.call_not(flag).expect("");
             assert_eq!(e.pc, 2);
+            e.ret_not(flag).expect("");
+            assert_eq!(e.pc, 2);
             e.reg.flip_flag(flag);
             e.call_not(flag).expect("");
             assert_eq!(e.pc, 0x1111);
-            e.ret().expect("");
+            e.ret_not(flag).expect("");
             assert_eq!(e.pc, 4);
             e.pc = 0;
         }

--- a/emulator/src/core/emulator.rs
+++ b/emulator/src/core/emulator.rs
@@ -73,7 +73,7 @@ impl Emulator {
                 }
             }
             0xcd => {
-                // CZ addr
+                // CALL addr
                 let adr = self.read_addr();
                 self.call(adr);
             }
@@ -93,6 +93,18 @@ impl Emulator {
             0xd1 => {
                 // POP D
                 self.reg["de"] = self.pop();
+            }
+            0xd2 => {
+                // JNC adr
+                if !self.reg.get_flag("carry") {
+                    self.pc = self.read_addr();
+                } else {
+                    self.pc += 2;
+                }
+            }
+            0xd3 => {
+                // OUT
+                unimplemented!()
             }
             _ => unimplemented!("Opcode not yet implemented")
         }
@@ -175,5 +187,14 @@ mod emulator_tests {
         e.reg.set_flag("zero");
         e.execute_next().expect("Fuck");
         assert_eq!(e.pc, 0x0003);
+
+        // Test JNZ
+        e.ram.load_vec(vec![0xc2, 0x34, 0x12, 0xc2, 0x34, 0x12], 0x3);
+        e.reg.set_flag("zero");
+        e.execute_next().expect("Fuck");
+        assert_eq!(e.pc, 0x6);
+        e.reg.flip_flag("zero");
+        e.execute_next().expect("Fuck");
+        assert_eq!(e.pc, 0x1234);
     }
 }

--- a/emulator/src/core/emulator.rs
+++ b/emulator/src/core/emulator.rs
@@ -25,11 +25,14 @@ impl Emulator {
         match opcode {
             0xc2 => {
                 // JNZ adr
+                /*
                 if !self.reg.get_flag("zero") {
                     self.pc = self.read_addr();
                 } else {
                     self.pc += 2;
                 }
+                */
+                self.jmp_not("zero");
             }
             0xc3 => {
                 // JMP adr
@@ -57,11 +60,15 @@ impl Emulator {
             }
             0xca => {
                 // JZ adr
+                /*
                 if self.reg.get_flag("zero") {
                     self.pc = self.read_addr();
                 } else {
                     self.pc += 2;
                 }
+                */
+                self.jmp_if("zero");
+                
             }
             0xcc => {
                 // CZ addr
@@ -106,9 +113,35 @@ impl Emulator {
                 // OUT
                 unimplemented!()
             }
+            0xd4 => {
+                // CNC adr
+                if !self.reg.get_flag("carry") {
+                    let adr = self.read_addr();
+                    self.call(adr);
+                } else {
+                    self.pc += 2;
+                }
+
+            }
             _ => unimplemented!("Opcode not yet implemented")
         }
         Ok(())
+    }
+
+    fn jmp_not(&mut self, flag: &str) {
+        if !self.reg.get_flag(flag) {
+            self.pc = self.read_addr();
+        } else {
+            self.pc += 2;
+        }
+    }
+
+    fn jmp_if(&mut self, flag: &str) {
+        if self.reg.get_flag(flag) {
+            self.pc = self.read_addr();
+        } else {
+            self.pc += 2;
+        }
     }
 
     fn call(&mut self, adr: u16) {

--- a/emulator/src/core/emulator.rs
+++ b/emulator/src/core/emulator.rs
@@ -23,13 +23,63 @@ impl Emulator {
         let opcode = self.ram[self.pc];
         self.pc += 1;
         match opcode {
+            0xc2 => {
+                // JNZ adr
+                if !self.reg.get_flag("zero") {
+                    self.pc = self.read_addr();
+                }
+            }
+            0xc3 => {
+                // JMP adr
+                self.pc = self.read_addr();
+            }
+            0xc4 => unimplemented!(),
+            0xc5 => unimplemented!(),
+            0xc6 => unimplemented!(),
+            0xc7 => unimplemented!(),
+            0xc8 => unimplemented!(),
+            0xc9 => unimplemented!(),
+            0xca => {
+                // JZ adr
+                if self.reg.get_flag("zero") {
+                    self.pc = self.read_addr();
+                }
+            }
             _ => unimplemented!("Opcode not yet implemented")
         }
         Ok(())
+    }
+
+    fn push(&mut self, val: u16) {
+        self.sp += 1;
+        self.ram[self.sp] = (val >> 8) as u8;
+        self.sp += 1;
+        self.ram[self.sp] = val as u8;
+    }
+
+    fn read_addr(&mut self) -> u16 {
+        let low = self.ram[self.pc] as u16;
+        self.pc += 1;
+        let high = self.ram[self.pc] as u16;
+        self.pc += 1;
+        (high << 8) | low
     }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn test_jmps() -> Result<(), &'static str> {
+        let mut e = Emulator::new();
+
+        // Test JMP
+        e.ram[0] = 0xc3;
+        e.ram[1] = 0xcd;
+        e.ram[2] = 0xab;
+        e.execute_next()?;
+        assert_eq!(e.pc, 0xabcd);
+        Ok(())
+    }
 }

--- a/emulator/src/core/emulator.rs
+++ b/emulator/src/core/emulator.rs
@@ -198,11 +198,11 @@ impl Emulator {
 }
 
 #[cfg(test)]
-mod emulator_tests {
+mod tests {
     use super::*;
 
     #[test]
-    fn test_push_pop() {
+    fn push_pop() {
         let mut e = Emulator::new();
 
         e.sp = 0x3fff;
@@ -216,7 +216,7 @@ mod emulator_tests {
     }
 
     #[test]
-    fn test_call_ret() {
+    fn call_ret() {
         let mut e = Emulator::new();
 
         e.sp = 0x3fff;
@@ -231,7 +231,7 @@ mod emulator_tests {
     }
 
     #[test]
-    fn test_jmps() {
+    fn jmps() {
         let mut e = Emulator::new();
 
         // Test JMP

--- a/emulator/src/core/emulator.rs
+++ b/emulator/src/core/emulator.rs
@@ -1,7 +1,6 @@
 use crate::core::ram::*;
 use crate::core::register::RegisterArray;
 
-
 pub struct Emulator {
     pc: u16,
     sp: u16,
@@ -58,17 +57,11 @@ impl Emulator {
             }
             0xcc => {
                 // CZ addr
-                if self.reg.get_flag("zero") {
-                    let adr = self.read_addr();
-                    self.call(adr);
-                } else {
-                    self.pc += 2;
-                }
+                self.call_if("zero");
             }
             0xcd => {
                 // CALL addr
-                let adr = self.read_addr();
-                self.call(adr);
+                self.call_imm();
             }
             0xce => {
                 unimplemented!()
@@ -97,12 +90,7 @@ impl Emulator {
             }
             0xd4 => {
                 // CNC adr
-                if !self.reg.get_flag("carry") {
-                    let adr = self.read_addr();
-                    self.call(adr);
-                } else {
-                    self.pc += 2;
-                }
+                self.call_not("carry");
 
             }
             _ => unimplemented!("Opcode not yet implemented")
@@ -124,6 +112,27 @@ impl Emulator {
         } else {
             self.pc += 2;
         }
+    }
+
+    fn call_not(&mut self, flag: &str) {
+        if !self.reg.get_flag(flag) {
+            self.call_imm();
+        } else {
+            self.pc += 2;
+        }
+    }
+
+    fn call_if(&mut self, flag: &str) {
+        if self.reg.get_flag(flag) {
+            self.call_imm();
+        } else {
+            self.pc += 2;
+        }
+    }
+
+    fn call_imm(&mut self) {
+        self.push(self.pc);
+        self.pc = self.read_addr();
     }
 
     fn call(&mut self, adr: u16) {

--- a/emulator/src/core/mod.rs
+++ b/emulator/src/core/mod.rs
@@ -1,4 +1,3 @@
 pub mod emulator;
 pub mod ram;
 pub mod register;
-pub mod testing_utils;

--- a/emulator/src/core/mod.rs
+++ b/emulator/src/core/mod.rs
@@ -1,3 +1,4 @@
 pub mod emulator;
 pub mod ram;
 pub mod register;
+pub mod testing_utils;

--- a/emulator/src/core/ram.rs
+++ b/emulator/src/core/ram.rs
@@ -75,11 +75,11 @@ impl Index<Range<usize>> for DefaultRam {
 }
 
 #[cfg(test)]
-mod ram_tests {
+mod tests {
     use super::*;
 
     #[test]
-    fn test_ram() {
+    fn ram() {
         let mut r = DefaultRam::new();
 
         r[0] = 1;

--- a/emulator/src/core/ram.rs
+++ b/emulator/src/core/ram.rs
@@ -18,7 +18,7 @@ pub trait RAM: Index<u16, Output=u8> + IndexMut<u16, Output=u8> {
 
 impl RAM for DefaultRam {
     fn size(&self) -> usize {
-        self.mem.len()
+        RAM_SIZE
     }
 
     fn load_vec(&mut self, vec: Vec<u8>, start: u16) {

--- a/emulator/src/core/ram.rs
+++ b/emulator/src/core/ram.rs
@@ -12,11 +12,21 @@ pub struct DefaultRam {
 
 pub trait RAM: Index<u16, Output=u8> + IndexMut<u16, Output=u8> {
     fn size(&self) -> usize;
+
+    fn load_vec(&mut self, vec: Vec<u8>, start: u16);
 }
 
 impl RAM for DefaultRam {
     fn size(&self) -> usize {
         self.mem.len()
+    }
+
+    fn load_vec(&mut self, vec: Vec<u8>, start: u16) {
+        let mut idx = start;
+        for byte in vec {
+            self[idx] = byte;
+            idx += 1;
+        }
     }
 }
 
@@ -32,14 +42,6 @@ impl DefaultRam {
      */
     pub fn new() -> Self {
         Self { mem: [0; RAM_SIZE] }
-    }
-
-    pub fn load_vec(&mut self, vec: Vec<u8>, start: u16) {
-        let mut idx = start;
-        for byte in vec {
-            self[idx] = byte;
-            idx += 1;
-        }
     }
 
     pub fn load_file(&mut self, path: &str, start: u16) -> io::Result<()> {

--- a/emulator/src/core/register.rs
+++ b/emulator/src/core/register.rs
@@ -69,6 +69,10 @@ impl RegisterArray {
             }
         }
     }
+
+    pub fn set_flags(&mut self, flags: u8) {
+        self.psw.bytes.1 = flags;
+    }
 }
 
 impl Index<char> for RegisterArray {

--- a/emulator/src/core/register.rs
+++ b/emulator/src/core/register.rs
@@ -144,11 +144,11 @@ impl IndexMut<&str> for RegisterArray {
 }
 
 #[cfg(test)]
-mod register_tests {
+mod tests {
     use super::*;
 
     #[test]
-    fn test_registerarray() {
+    fn registerarray() {
         let mut regs = RegisterArray::new();
 
         regs["wz"] = 0xabcd;
@@ -168,7 +168,7 @@ mod register_tests {
     }
 
     #[test]
-    fn test_flags() {
+    fn flags() {
         let mut regs = RegisterArray::new();
 
         regs.set_flag("zero");


### PR DESCRIPTION
All the opcodes are implemented and there is a decent amount of tests.

However there are few tests actually testing opcode decoding from ram. The way i think this should be done, is by running .asm files in the emulator that place specific values in specific registers and assertings these register values after execution terminates. Therefore, in order to construct these tests:
a) the assembler needs to be working (because writing machine code by hand is a drag)
b) MOV statements should be implemented, as they are required for manipulating registers.

Therefore i would recommend delaying the writing of these tests to the appropriate time.