### PR TITLE
added removal of org statements

### DIFF
--- a/emulator/src/kreator/assembler.rs
+++ b/emulator/src/kreator/assembler.rs
@@ -52,7 +52,7 @@ impl Assembler {
         for line in preprocessed_code {
             let line = label_regex.replace(&line, "").trim().to_string();
 
-            if !line.is_empty() {
+            if !line.is_empty() && !line.contains("ORG ") {
                 machine_code.extend(to_machine_code(line)?);
             }
         }
@@ -789,6 +789,7 @@ mod tests {
         IF 20\n
         EI\n
         ENDIF\n
+        ORG 100H\n
         END\n";
 
         let result = vec![0xc3, 0x6, 0x0, 0x81, 0xC1, 0xC8, 0xFB];


### PR DESCRIPTION
This is more of a hotfix thing. The problem with our current implementation is the following:
1. The assembler knows how to translate lines into byte code
2. Determining origins requires knowledge of the amount of bytes executed so far (as origins are meta information, not found in the byte code)
3. To determine origins pseudo instructions have to be removed beforehand

This leads to the issue that in order to determine origins the assembler class requires the preprocessor class to go over the code without removing `ORG` statements as the latter cannot handle them itself. While this is not a functional issue (the implementation works) it does increase the complexity and blurs the line between preprocessor and assembler, creating technical debt.

I suggest to apply this fix in order for us to continue working on more important things and get back to this later on if we have the time and need to do so.

Closes #32 