### PR TITLE
Feature/line mapping

### DIFF
--- a/emulator/src/kreator/assembler.rs
+++ b/emulator/src/kreator/assembler.rs
@@ -274,7 +274,7 @@ fn to_machine_code(instruction: String) -> Result<Vec<u8>, &'static str> {
             "XTHL" => return Ok(vec![0xe3]),
             _ => return Err("Could not match instruction"),
         },
-    };
+    }
 }
 
 fn evaluate_str(str: &str) -> u16 {

--- a/emulator/src/kreator/assembler.rs
+++ b/emulator/src/kreator/assembler.rs
@@ -1,5 +1,5 @@
 use super::parser::eval;
-use super::preprocessor::get_preprocessed_code;
+use super::preprocessor::{get_preprocessed_code, get_line_map};
 use core::fmt;
 use regex::Regex;
 use std::{collections::HashMap, hash::Hash};
@@ -54,6 +54,10 @@ impl Assembler {
             }
         }
         Ok(machine_code)
+    }
+
+    pub fn get_line_map(&self) -> HashMap<u16, usize> {
+        get_line_map(&self.code)
     }
 
     pub fn get_origins(&self) -> Vec<(u16, u16)> {

--- a/emulator/src/kreator/assembler.rs
+++ b/emulator/src/kreator/assembler.rs
@@ -56,7 +56,7 @@ impl Assembler {
         Ok(machine_code)
     }
 
-    pub fn get_line_map(&self) -> HashMap<u16, usize> {
+    pub fn get_line_map(&self) -> Result<HashMap<u16, usize>, &'static str> {
         get_line_map(&self.code)
     }
 

--- a/emulator/src/kreator/assembler.rs
+++ b/emulator/src/kreator/assembler.rs
@@ -31,13 +31,11 @@ impl fmt::Display for Assembler {
 
 impl Assembler {
     pub fn new(input_code: &str) -> Self {
-        let mut lines = Vec::new();
-        let comment_regex = Regex::new(r";.*").unwrap();
+        let mut lines:Vec<String> = Vec::new();
+        //let comment_regex = Regex::new(r";.*").unwrap();
 
         for line in input_code.split("\n") {
-            let line = comment_regex.replace(line, "");
-            let line = line.trim_end();
-            lines.push(String::from(line));
+            lines.push(line.trim().to_string());
         }
 
         Self { code: lines }
@@ -458,7 +456,7 @@ mod tests {
         let code_file = "MOV A B \n JMP label \nlabel: INC ACC   ";
         let assembler = Assembler::new(code_file);
 
-        let expected_text = "MOV A B\n JMP label\nlabel: INC ACC";
+        let expected_text = "MOV A B\nJMP label\nlabel: INC ACC";
         assert_eq!(expected_text, format!("{}", assembler));
     }
 
@@ -467,7 +465,7 @@ mod tests {
         let code_file = "MOV A B \r\n JMP label \r\nlabel: INC ACC  ";
         let assembler = Assembler::new(code_file);
 
-        let expected_text = "MOV A B\n JMP label\nlabel: INC ACC";
+        let expected_text = "MOV A B\nJMP label\nlabel: INC ACC";
         assert_eq!(expected_text, format!("{}", assembler));
     }
 
@@ -479,11 +477,11 @@ mod tests {
     }
 
     #[test]
-    fn display_remove_comments() {
+    fn display_with_comments() {
         let code_file = " \n;comment\nMOV A B ;comment\n;";
         let assembler = Assembler::new(code_file);
 
-        let expected_text = "\n\nMOV A B\n";
+        let expected_text = "\n;comment\nMOV A B ;comment\n;";
         assert_eq!(expected_text, format!("{}", assembler));
     }
 

--- a/emulator/src/kreator/assembler.rs
+++ b/emulator/src/kreator/assembler.rs
@@ -32,7 +32,6 @@ impl fmt::Display for Assembler {
 impl Assembler {
     pub fn new(input_code: &str) -> Self {
         let mut lines:Vec<String> = Vec::new();
-        //let comment_regex = Regex::new(r";.*").unwrap();
 
         for line in input_code.split("\n") {
             lines.push(line.trim().to_string());

--- a/emulator/src/kreator/preprocessor.rs
+++ b/emulator/src/kreator/preprocessor.rs
@@ -19,8 +19,9 @@ pub fn get_preprocessed_code(code: &Vec<String>) -> Result<Vec<String>, &'static
     let mut preprocessed_code: Vec<String> = Vec::new();
     let mut pc = 0;
 
-    let labels = get_labels(code)?;
-    let code = replace_macros(code)?;
+    let code = get_commentless_code(&code)?;
+    let labels = get_labels(&code)?;
+    let code = replace_macros(&code)?;
 
     for line in code {
         let mut owned_line = line.trim().to_string();
@@ -104,6 +105,16 @@ pub fn get_preprocessed_code(code: &Vec<String>) -> Result<Vec<String>, &'static
     // remove "END" from code
     preprocessed_code.remove(preprocessed_code.len() - 1);
     Ok(preprocessed_code)
+}
+
+fn get_commentless_code(code: &Vec<String>) -> Result<Vec<String>, &'static str> {
+    let comment_regex = Regex::new(r";.*").unwrap();
+    let mut new_code = Vec::new();
+
+    for line in code {
+        new_code.push(comment_regex.replace_all(line, "").to_string());
+    }
+    Ok(new_code)
 }
 
 fn eval_str(str: String) -> u16 {
@@ -508,6 +519,14 @@ fn has_correct_end(code: &Vec<String>) -> bool {
 
 mod tests {
     use super::*;
+
+    #[test]
+    fn remove_comments() {
+        let ppc = get_commentless_code(&convert_input(vec![";comment\nMOV A, B;asdf\n;END;\nEND"]));
+        let expected = convert_input(vec!["\nMOV A, B\n\nEND"]);
+
+        assert_eq!(ppc, Ok(expected));
+    }
 
     #[test]
     fn preprocessing_pc() {

--- a/emulator/src/kreator/preprocessor.rs
+++ b/emulator/src/kreator/preprocessor.rs
@@ -111,8 +111,8 @@ pub fn get_line_map(code: &Vec<String>) -> HashMap<u16, usize> {
     let (one_byte_labels, two_byte_labels, three_byte_labels) = get_opc_by_byte_size();
     let label_decl = Regex::new(LABEL_DECL).unwrap();
     
-    let mut byte_to_line: HashMap<u16, usize> = HashMap::new();
-    let mut macro_byte_to_line = HashMap::new();
+    let mut byte_to_line_map: HashMap<u16, usize> = HashMap::new();
+    let mut macro_map = HashMap::new();
     let mut line_index: usize = 0;
     let mut byte_index: u16 = 0;
     let mut in_macro = false;
@@ -145,7 +145,7 @@ pub fn get_line_map(code: &Vec<String>) -> HashMap<u16, usize> {
             for value in local_map.values_mut() {
                 *value += line_index + 1;
             }
-            macro_byte_to_line.insert(macro_name, local_map);
+            macro_map.insert(macro_name, local_map);
             line_index += 1;
             continue;
         }
@@ -155,28 +155,28 @@ pub fn get_line_map(code: &Vec<String>) -> HashMap<u16, usize> {
         } else {
             &line
         };
-        if macro_byte_to_line.contains_key(&operand.to_string()) {
-            let local_map = macro_byte_to_line.get(&operand.to_string()).unwrap();
+        if macro_map.contains_key(&operand.to_string()) {
+            let local_map = macro_map.get(&operand.to_string()).unwrap();
             for (local_byte, line) in local_map {
-                byte_to_line.insert(local_byte + byte_index, *line);
+                byte_to_line_map.insert(local_byte + byte_index, *line);
             }
             byte_index += local_map.len() as u16;
         } else if one_byte_labels.contains(&operand) {
-            byte_to_line.insert(byte_index, line_index);
+            byte_to_line_map.insert(byte_index, line_index);
             byte_index += 1;
         } else if two_byte_labels.contains(&operand) {
-            byte_to_line.insert(byte_index, line_index);
-            byte_to_line.insert(byte_index + 1, line_index);
+            byte_to_line_map.insert(byte_index, line_index);
+            byte_to_line_map.insert(byte_index + 1, line_index);
             byte_index += 2;
         } else if three_byte_labels.contains(&operand) {
-            byte_to_line.insert(byte_index, line_index);
-            byte_to_line.insert(byte_index + 1, line_index);
-            byte_to_line.insert(byte_index + 2, line_index);
+            byte_to_line_map.insert(byte_index, line_index);
+            byte_to_line_map.insert(byte_index + 1, line_index);
+            byte_to_line_map.insert(byte_index + 2, line_index);
             byte_index += 3;
         }
         line_index += 1;
     }
-    byte_to_line
+    byte_to_line_map
 }
 
 fn get_commentless_code(code: &Vec<String>) -> Vec<String> {


### PR DESCRIPTION
Closes #40 

The `assembler` struct now offers the method `get_line_map()` that returns a map containing all bytes that will be output if the code is assembled (referring to their indices starting at 0), mapped to the corresponding line (starting at 0).

I should have covered the biggest pain points (IF and MACRO) with respective tests, so everything _should_ run smoothly.