### PR TITLE
Fixes and optimizations

### DIFF
--- a/emulator/src/kreator/assembler.rs
+++ b/emulator/src/kreator/assembler.rs
@@ -2,9 +2,8 @@ use super::parser::eval;
 use super::preprocessor::{get_preprocessed_code, get_line_map};
 use core::fmt;
 use regex::Regex;
-use std::{collections::HashMap, hash::Hash};
 
-pub const LABEL_DECL: &str = r"^( *[a-zA-Z@?][a-zA-Z@?0-9]{0,4}:)";
+pub const LABEL_DECL: &str = r"^( *[a-zA-Z@?][a-zA-Z@?0-9]*:)";
 
 pub fn get_reserved_names() -> Vec<&'static str> {
     vec![

--- a/emulator/src/kreator/assembler.rs
+++ b/emulator/src/kreator/assembler.rs
@@ -41,7 +41,6 @@ impl Assembler {
     }
 
     pub fn assemble(&self) -> Result<Vec<u8>, &'static str> {
-        let label_regex = Regex::new(LABEL_DECL).unwrap();
         let preprocessed_code = get_preprocessed_code(&self.code)?;
         let origins = self.get_origins();
 
@@ -50,8 +49,6 @@ impl Assembler {
         let mut current_byte_index: usize = 0;
 
         for line in preprocessed_code {
-            let line = label_regex.replace(&line, "").trim().to_string();
-
             if !line.is_empty() && !line.contains("ORG ") {
                 for (origin_index, next_address) in &origins {
                     if current_byte_index == usize::from(*origin_index) {

--- a/emulator/src/kreator/preprocessor.rs
+++ b/emulator/src/kreator/preprocessor.rs
@@ -885,7 +885,7 @@ mod tests {
     #[test]
     fn long_labels() {
         let code = convert_input(vec!["instruction: MOV A,B"]);
-        let mut labels:HashMap<String, u16> = HashMap::new();
+        let mut labels: HashMap<String, u16> = HashMap::new();
         labels.insert("instr".to_string(), 0);
 
         assert_eq!(Ok(labels), get_labels(&code));

--- a/emulator/src/kreator/preprocessor.rs
+++ b/emulator/src/kreator/preprocessor.rs
@@ -65,11 +65,11 @@ pub fn get_preprocessed_code(code: &Vec<String>) -> Result<Vec<String>, &'static
             }
         }
 
-        pc += 1;
+        pc += get_byte_amount_of_line(&line);
         if !owned_line.is_empty() {
             preprocessed_code.push(owned_line.trim().to_string());
         } else {
-            pc -= 1;
+            pc -= get_byte_amount_of_line(&line);
         }
     }
 
@@ -657,12 +657,12 @@ mod tests {
 
     #[test]
     fn preprocessing_pc() {
-        let code = vec!["MOV A,B", "JMP $", "END"];
+        let code = vec!["MOV A,B", "LDA 3", "JMP $", "END"];
         let ppc = get_preprocessed_code(&convert_input(code));
-        assert_eq!(Ok(convert_input(vec!["MOV A,B", "JMP 1"])), ppc);
+        assert_eq!(Ok(convert_input(vec!["MOV A,B", "LDA 3", "JMP 4"])), ppc);
 
-        let preprocessed_code = get_preprocessed_code(&convert_input(vec!["MOV $, $", "END"]));
-        assert_eq!(Ok(vec!["MOV 0, 0".to_string()]), preprocessed_code);
+        let preprocessed_code = get_preprocessed_code(&convert_input(vec!["LDA 0", "MOV $, $", "END"]));
+        assert_eq!(Ok(convert_input(vec!["LDA 0", "MOV 3, 3"])), preprocessed_code);
     }
 
     #[test]

--- a/emulator/src/kreator/preprocessor.rs
+++ b/emulator/src/kreator/preprocessor.rs
@@ -17,7 +17,7 @@ pub fn get_preprocessed_code(code: &Vec<String>) -> Result<Vec<String>, &'static
     let mut preprocessed_code: Vec<String> = Vec::new();
     let mut pc = 0;
 
-    let code = replace_variable_usages(&get_commentless_code(&code))?;
+    let code = replace_variable_usages(&code)?;
     let labels = get_labels(&code)?;
     let code = replace_macros(&code)?;
 

--- a/emulator/src/kreator/preprocessor.rs
+++ b/emulator/src/kreator/preprocessor.rs
@@ -607,7 +607,7 @@ fn has_correct_end(code: &Vec<String>) -> bool {
         if line.is_empty() {
             continue;
         }
-        if line.trim().contains("END") && !line.contains("ENDIF") && !line.contains("ENDM") {
+        if line.trim().eq("END") {
             if has_end {
                 return false;
             }
@@ -618,7 +618,7 @@ fn has_correct_end(code: &Vec<String>) -> bool {
             return false;
         }
     }
-    return has_end;
+    has_end
 }
 
 mod tests {

--- a/emulator/src/kreator/preprocessor.rs
+++ b/emulator/src/kreator/preprocessor.rs
@@ -32,11 +32,6 @@ pub fn get_preprocessed_code(code: &Vec<String>) -> Result<Vec<String>, &'static
             owned_line = decl_regex.replace(&owned_line, "").to_string();
         }
 
-        // replace labels with according values
-        for (key, value) in &labels {
-            owned_line = owned_line.replace(key, &value.to_string());
-        }
-
         owned_line = replace_names(&owned_line, &to_string_map(&labels));
 
         if owned_line.contains(" EQU ") || owned_line.contains(" SET ") {
@@ -694,15 +689,12 @@ mod tests {
 
     #[test]
     fn label_replacement() {
-        let ppc = get_preprocessed_code(&convert_input(vec!["lab: lab", "END"]));
-        assert_eq!(Ok(vec!["0".to_string()]), ppc);
-
         let ppc =
-            get_preprocessed_code(&convert_input(vec!["MOV A, lab", "lab: RRC", "END"]));
-        assert_eq!(Ok(convert_input(vec!["MOV A, 1", "RRC"])), ppc);
+            get_preprocessed_code(&convert_input(vec!["LXI B, lab", "lab: RRC", "END"]));
+        assert_eq!(Ok(convert_input(vec!["LXI B, 3", "RRC"])), ppc);
 
-        let ppc = get_preprocessed_code(&convert_input(vec!["lab:", "MOV A,B", "label:", "MOV label, lab", "END"]));
-        assert_eq!(Ok(convert_input(vec!["MOV A,B", "MOV 1, 0"])), ppc);
+        let ppc = get_preprocessed_code(&convert_input(vec!["lab:", "MOV A,B", "label:", "IN label", "OUT lab", "END"]));
+        assert_eq!(Ok(convert_input(vec!["MOV A,B", "IN 1", "OUT 0"])), ppc);
     }
 
     #[test]

--- a/emulator/src/kreator/preprocessor.rs
+++ b/emulator/src/kreator/preprocessor.rs
@@ -17,9 +17,9 @@ pub fn get_preprocessed_code(code: &Vec<String>) -> Result<Vec<String>, &'static
     let mut preprocessed_code: Vec<String> = Vec::new();
     let mut pc = 0;
 
-    let labels = get_labels(&code)?;
     let code = replace_macros(&code)?;
     let code = replace_variable_usages(&code)?;
+    let labels = get_labels(&code)?;
 
     for line in code {
         let mut owned_line = line.trim().to_string();

--- a/emulator/src/kreator/preprocessor.rs
+++ b/emulator/src/kreator/preprocessor.rs
@@ -174,21 +174,16 @@ fn replace_variable_usages(code: &Vec<String>) -> Result<Vec<String>, &'static s
     for line in code {
         let mut line = line.trim().to_string();
 
-        // replace values of variables declared by EQU
-        for (key, value) in &equ_assignments {
-            line = line.replace(&format!(" {} ", key), &format!(" {}", value));
-            line = line.replace(&format!(",{} ", key), &format!(",{}", value));
-            if line.ends_with(key) {
-                line = line.replace(key, &value.to_string());
-            }
-        }
-
-        // replace values of variables declared by SET
-        for (key, value) in &set_assignments {
-            line = line.replace(&format!(" {} ", key), &format!(" {}", value));
-            line = line.replace(&format!(",{} ", key), &format!(",{}", value));
-            if line.ends_with(key) {
-                line = line.replace(key, &value.to_string());
+        for assignment_map in vec![&equ_assignments.clone(), &set_assignments.clone()] {
+            for (key, value) in assignment_map {
+                line = line.replace(&format!(" {} ", key), &format!(" {}", value));
+                line = line.replace(&format!(",{} ", key), &format!(",{}", value));
+                if line.ends_with(&format!(" {}", key)) {
+                    line = line.replace(&format!(" {}", key), &format!(" {}", &value.to_string()));
+                }
+                if line.ends_with(&format!(",{}", key)) {
+                    line = line.replace(&format!(" {}", key), &format!(" {}", &value.to_string()));
+                }
             }
         }
 
@@ -928,6 +923,11 @@ mod tests {
 
         assert_eq!("OUT 4", ppc[2]);
         assert_eq!("OUT 5", ppc[3]);
+
+        let code = convert_input(vec!["Ba SET 5", "FooBa SET 10", "OUT FooBa"]);
+        let ppc = replace_variable_usages(&code).unwrap();
+
+        assert_eq!("OUT 10", ppc[2]);
     }
 
     #[test]

--- a/emulator/src/kreator/preprocessor.rs
+++ b/emulator/src/kreator/preprocessor.rs
@@ -473,12 +473,15 @@ fn get_labels(code: &Vec<String>) -> Result<HashMap<String, u16>, &'static str> 
     let mut mem_address: u16 = 0;
 
     for line in code {
+        if line.trim().is_empty() {
+            continue;
+        }
         if line.starts_with("ORG ") {
             mem_address = eval(line.split_once("ORG ").unwrap().1) as u16;
         }
         if label_regex.is_match(&line) {
-            let split = line.split(":").collect::<Vec<&str>>();
-            let mut label = split[0].trim_start().to_string();
+            let (label_name, operand) = line.split_once(":").unwrap();
+            let mut label = label_name.trim_start().to_string();
             while label.len() > 5 {
                 label.pop();
             }
@@ -486,7 +489,7 @@ fn get_labels(code: &Vec<String>) -> Result<HashMap<String, u16>, &'static str> 
                 return Err("illegal label name");
             }
             temp_labels.push(label.to_string());
-            if !split[1].trim().is_empty() {
+            if !operand.trim().is_empty() {
                 while let Some(new_label) = temp_labels.pop() {
                     if labels.contains_key(&new_label) {
                         return Err("label must not be assigned twice");
@@ -835,7 +838,7 @@ mod tests {
 
     #[test]
     fn empty_label() {
-        let labels = get_labels(&convert_input(vec!["label:"]));
+        let labels = get_labels(&convert_input(vec!["label:", ""]));
         assert_eq!(Err("labels must not point to an empty address!"), labels);
     }
 

--- a/emulator/src/kreator/preprocessor.rs
+++ b/emulator/src/kreator/preprocessor.rs
@@ -176,14 +176,20 @@ fn replace_variable_usages(code: &Vec<String>) -> Result<Vec<String>, &'static s
 
         // replace values of variables declared by EQU
         for (key, value) in &equ_assignments {
-            line = line.replace(&format!(" {}", key), &format!(" {}", value));
-            line = line.replace(&format!(",{}", key), &format!(",{}", value));
+            line = line.replace(&format!(" {} ", key), &format!(" {}", value));
+            line = line.replace(&format!(",{} ", key), &format!(",{}", value));
+            if line.ends_with(key) {
+                line = line.replace(key, &value.to_string());
+            }
         }
 
         // replace values of variables declared by SET
         for (key, value) in &set_assignments {
-            line = line.replace(&format!(" {}", key), &format!(" {}", value));
-            line = line.replace(&format!(",{}", key), &format!(",{}", value));
+            line = line.replace(&format!(" {} ", key), &format!(" {}", value));
+            line = line.replace(&format!(",{} ", key), &format!(",{}", value));
+            if line.ends_with(key) {
+                line = line.replace(key, &value.to_string());
+            }
         }
 
         if line.contains(" SET ") {
@@ -913,6 +919,15 @@ mod tests {
 
         assert_eq!("OUT test", ppc[0]);
         assert_eq!("OUT 5", ppc[2]);
+    }
+
+    #[test]
+    fn longer_variable_names() {
+        let code = convert_input(vec!["test EQU 5", "te EQU 4", "OUT te", "OUT test"]);
+        let ppc = replace_variable_usages(&code).unwrap();
+
+        assert_eq!("OUT 4", ppc[2]);
+        assert_eq!("OUT 5", ppc[3]);
     }
 
     #[test]

--- a/emulator/src/kreator/preprocessor.rs
+++ b/emulator/src/kreator/preprocessor.rs
@@ -478,8 +478,11 @@ fn get_labels(code: &Vec<String>) -> Result<HashMap<String, u16>, &'static str> 
         }
         if label_regex.is_match(&line) {
             let split = line.split(":").collect::<Vec<&str>>();
-            let label = split[0].trim_start();
-            if reserved_names.contains(&label) {
+            let mut label = split[0].trim_start().to_string();
+            while label.len() > 5 {
+                label.pop();
+            }
+            if reserved_names.contains(&&label[..]) {
                 return Err("illegal label name");
             }
             temp_labels.push(label.to_string());
@@ -825,6 +828,9 @@ mod tests {
     fn duplicate_labels() {
         let labels = get_labels(&convert_input(vec!["label:", "label:", "MOV A,B"]));
         assert_eq!(Err("label must not be assigned twice!"), labels);
+
+        let code = convert_input(vec!["instr:", "instruction:", "MOV A,B"]);
+        assert_eq!(Err("label must not be assigned twice!"), get_labels(&code));
     }
 
     #[test]
@@ -837,6 +843,15 @@ mod tests {
     fn illegal_label() {
         let labels = get_labels(&vec!["IF: RRC".to_string()]);
         assert_eq!(Err("illegal label name"), labels);
+    }
+
+    #[test]
+    fn long_labels() {
+        let code = convert_input(vec!["instruction: MOV A,B"]);
+        let mut labels:HashMap<String, u16> = HashMap::new();
+        labels.insert("instr".to_string(), 0);
+
+        assert_eq!(Ok(labels), get_labels(&code));
     }
 
     #[test]


### PR DESCRIPTION
I know this PR is rather large and unstructured, I'll excuse myself in advance. When reviewing code I would advise you to do so commitwise as I have implemented / fixed different things on this branch.
Relevant changes are
Structural / spec issues:
- Labels can now be as long as they want and will be shortened to a length of 5 (according to specs)
- the logical order of replacement operations has been changed to make sense
- the programs counter references ($) now reference the bytes instead of lines (compares to #38)

Methods:
- reverted the extraction of the method "get_equate_assignments" as it caused issues with variable scopes
- extracted code to a method to replace names in a line and changed occurences

Variables:
- variable replacement now checks for ifs when determining variable values
- variables declared with "SET" now inclued checking for name validity

Some minor optimizations.

All changes _should_ be covered by some form of test which will likely give you more information on why I changed certain things or what they improved. This PR _should_ be merged within due time as it fixes some major issues and some contents of the written report reference code that has been changed in here.